### PR TITLE
Include limits where necessary

### DIFF
--- a/include/jni/native_method.hpp
+++ b/include/jni/native_method.hpp
@@ -96,7 +96,7 @@ namespace jni
 
     /// High-level, lambda
 
-    template < class T, T... >
+    template < class T, T*... >
     struct NativeMethodMaker;
 
     template < class T, class R, class Subject, class... Args >
@@ -124,7 +124,6 @@ namespace jni
 
 
     /// High-level, function pointer
-
     template < class R, class Subject, class... Args, R (*method)(JNIEnv&, Subject, Args...) >
     struct NativeMethodMaker< R (JNIEnv&, Subject, Args...), method >
        {
@@ -186,7 +185,7 @@ namespace jni
 
     /// High-level peer, function pointer
 
-    template < class M, M >
+    template < class M, M* >
     class NativePeerFunctionPointerMethod;
 
     template < class R, class P, class... Args, R (*method)(JNIEnv&, P&, Args...) >

--- a/include/jni/wrapping.hpp
+++ b/include/jni/wrapping.hpp
@@ -4,7 +4,7 @@
 #include <cassert>
 #include <memory>
 #include <utility>
-
+#include <limits>
 #include <jni.h>
 
 namespace jni


### PR DESCRIPTION
using `std::numeric_limits` requires `<limits>`.