### PR TITLE
Add Local reference methods and wrappers

### DIFF
--- a/include/jni/functions.hpp
+++ b/include/jni/functions.hpp
@@ -145,14 +145,18 @@ namespace jni
 
 
     template < class T >
-    T* NewLocalRef(JNIEnv& env, T* ref)
+    UniqueLocalRef<T> NewLocalRef(JNIEnv& env, T* t)
        {
-        return CheckJavaException(env, Wrap<T*>(env.NewLocalRef(Unwrap(ref))));
+        jobject* obj = Wrap<jobject*>(env.NewLocalRef(Unwrap(t)));
+        CheckJavaException(env);
+        if (t && !obj)
+            throw std::bad_alloc();
+        return UniqueLocalRef<T>(reinterpret_cast<T*>(obj), LocalRefDeleter(env));
        }
 
-    inline void DeleteLocalRef(JNIEnv& env, jobject* localRef)
+    inline void DeleteLocalRef(JNIEnv& env, UniqueLocalRef<jobject>&& ref)
        {
-        env.DeleteLocalRef(Unwrap(localRef));
+        env.DeleteLocalRef(Unwrap(ref.release()));
         CheckJavaException(env);
        }
 

--- a/include/jni/object.hpp
+++ b/include/jni/object.hpp
@@ -32,6 +32,12 @@ namespace jni
     template < class TagType >
     using UniqueWeakObject = std::unique_ptr< const Object<TagType>, WeakObjectRefDeleter<TagType> >;
 
+    template < class TagType >
+    class LocalObjectRefDeleter;
+
+    template < class TagType = ObjectTag >
+    using UniqueLocalObject = std::unique_ptr< const Object<TagType>, LocalObjectRefDeleter<TagType> >;
+
     template < class TheTag = ObjectTag >
     class Object
        {
@@ -141,6 +147,11 @@ namespace jni
                 return SeizeWeakRef(env, Object(jni::NewWeakGlobalRef(env, obj).release()));
                }
 
+            UniqueLocalObject<TagType> NewLocalRef(JNIEnv& env) const
+               {
+                return SeizeLocalRef(env, Object(jni::NewLocalRef(env, obj).release()));
+               }
+
             template < class OtherTag >
             bool IsInstanceOf(JNIEnv& env, const Class<OtherTag>& clazz) const
                {
@@ -202,6 +213,34 @@ namespace jni
     UniqueWeakObject<TagType> SeizeWeakRef(JNIEnv& env, Object<TagType>&& object)
        {
         return UniqueWeakObject<TagType>(PointerToValue<Object<TagType>>(std::move(object)), WeakObjectRefDeleter<TagType>(env));
+       };
+
+    template < class TagType >
+    class LocalObjectRefDeleter
+       {
+        private:
+            JNIEnv* env = nullptr;
+
+        public:
+            using pointer = PointerToValue< Object<TagType> >;
+
+            LocalObjectRefDeleter() = default;
+            LocalObjectRefDeleter(JNIEnv& e) : env(&e) {}
+
+            void operator()(pointer p) const
+               {
+                if (p)
+                   {
+                    assert(env);
+                    env->DeleteLocalRef(Unwrap(p->Get()));
+                   }
+               }
+       };
+
+    template < class TagType >
+    UniqueLocalObject<TagType> SeizeLocalRef(JNIEnv& env, Object<TagType>&& object)
+       {
+        return UniqueLocalObject<TagType>(PointerToValue<Object<TagType>>(std::move(object)), LocalObjectRefDeleter<TagType>(env));
        };
 
 

--- a/include/jni/ownership.hpp
+++ b/include/jni/ownership.hpp
@@ -66,6 +66,29 @@ namespace jni
     using UniqueWeakGlobalRef = std::unique_ptr< T, WeakGlobalRefDeleter >;
 
 
+    class LocalRefDeleter
+       {
+        private:
+            JNIEnv* env = nullptr;
+
+        public:
+            LocalRefDeleter() = default;
+            LocalRefDeleter(JNIEnv& e) : env(&e) {}
+
+            void operator()(jobject* p) const
+               {
+                if (p)
+                   {
+                    assert(env);
+                    env->DeleteLocalRef(Unwrap(p));
+                   }
+               }
+       };
+
+    template < class T >
+    using UniqueLocalRef = std::unique_ptr< T, LocalRefDeleter >;
+
+
     class StringCharsDeleter
        {
         private:

--- a/test/high_level.cpp
+++ b/test/high_level.cpp
@@ -72,6 +72,7 @@ int main()
 
     static bool calledNewGlobalRef = false;
     static bool calledNewWeakGlobalRef = false;
+    static bool calledNewLocalRef = false;
 
     env.functions->NewGlobalRef = [] (JNIEnv*, jobject obj) -> jobject
        {
@@ -93,6 +94,16 @@ int main()
        {
        };
 
+    env.functions->NewLocalRef = [] (JNIEnv*, jobject obj) -> jobject
+       {
+        calledNewLocalRef = true;
+        return obj;
+       };
+
+    env.functions->DeleteLocalRef = [] (JNIEnv*, jobject) -> void
+       {
+       };
+
     testClass.NewGlobalRef(env);
     assert(calledNewGlobalRef);
 
@@ -102,10 +113,12 @@ int main()
     jni::Object<Test> object { objectValue.Ptr() };
     object.NewGlobalRef(env);
     object.NewWeakGlobalRef(env);
+    object.NewLocalRef(env);
 
     jni::String string { stringValue.Ptr() };
     string.NewGlobalRef(env);
     string.NewWeakGlobalRef(env);
+    string.NewLocalRef(env);
 
 
     /// Constructor


### PR DESCRIPTION
While local references are disposed of automatically once JNI returns control to the JVM, there's a low limit on local references, and sometimes we need to release them to avoid hitting that limit. This adds a wrapper for a local reference that can be seized like global refs.

Note that to avoid duplicating references, you should predominantly use code like

```cpp
auto localRef = jni::SeizeLocalRef(env, std::move(ref));
```

rather than creating a reference via `ref.NewLocalRef()`. Using the latter creates a new reference, and makes it RAII managed rather than converting the existing reference to RAII.