### PR TITLE
Enable Class<>::Find() for Array objects

### DIFF
--- a/include/jni/array.hpp
+++ b/include/jni/array.hpp
@@ -5,10 +5,11 @@
 #include <jni/tagging.hpp>
 #include <jni/make.hpp>
 #include <jni/pointer_to_value.hpp>
+#include <jni/type_signature.hpp>
 
 namespace jni
    {
-    template < class E, class Enable = void >
+    template < class E, class Enable >
     class Array;
 
     template < class TagType >
@@ -106,6 +107,11 @@ namespace jni
 
             friend bool operator==( const Array& a, const Array& b )  { return a.Get() == b.Get(); }
             friend bool operator!=( const Array& a, const Array& b )  { return !( a == b ); }
+
+            static const char* Name()
+               {
+                return TypeSignature<Array<Object<TheTag>>>()();
+               }
 
             jsize Length(JNIEnv& env) const
                {

--- a/include/jni/type_signature.hpp
+++ b/include/jni/type_signature.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <jni/functions.hpp>
-#include <jni/object.hpp>
-#include <jni/array.hpp>
 
 #include <initializer_list>
 #include <string>
 
 namespace jni
    {
+    template < class TheTag > class Object;
+    template < class E, class Enable = void > class Array;
     template < class > struct TypeSignature;
 
     template <> struct TypeSignature< jboolean > { const char * operator()() const { return "Z"; } };


### PR DESCRIPTION
`Class<>::Find` currently calls the tag's `Name()` method, which means that it's currently quite ugly to retrieve an array class (e.g. `Object[]`) since you'd have to specify `[Ljava/util/Object;` as the `Name()` of the tag.

Instead, we could implement a `Name()` function on `Array<Object<...>>` specialization, so you could do `jni::Class<jni::Array<jni::Object<...>>>::Find(env)`.