### PR TITLE
Deduplicate tags to unique jni::Tag<...> types

### DIFF
--- a/include/jni/array.hpp
+++ b/include/jni/array.hpp
@@ -82,11 +82,11 @@ namespace jni
        };
 
     template < class TheTag >
-    class Array< Object<TheTag> >
+    class Array< TypedObject<TheTag> >
        {
         public:
             using TagType = TheTag;
-            using ElementType = Object<TagType>;
+            using ElementType = TypedObject<TagType>;
             using UntaggedType = jarray<jobject>;
             using UntaggedElementType = typename ElementType::UntaggedObjectType;
 
@@ -124,12 +124,12 @@ namespace jni
                 SetObjectArrayElement(env, SafeDereference(env, array), index, Untag(value));
                }
 
-            static Array<Object<TheTag>> New(JNIEnv& env, jsize length, const Class<TheTag>& clazz, const Object<TheTag>& initialElement = Object<TheTag>())
+            static Array<TypedObject<TheTag>> New(JNIEnv& env, jsize length, const TypedClass<TheTag>& clazz, const TypedObject<TheTag>& initialElement = TypedObject<TheTag>())
                {
-                return Array<Object<TheTag>>(&NewObjectArray(env, length, clazz, initialElement.Get()));
+                return Array<TypedObject<TheTag>>(&NewObjectArray(env, length, clazz, initialElement.Get()));
                }
 
-            UniqueArray<Object<TheTag>> NewGlobalRef(JNIEnv& env) const
+            UniqueArray<TypedObject<TheTag>> NewGlobalRef(JNIEnv& env) const
                {
                 return Seize(env, Array(jni::NewGlobalRef(env, array).release()));
                }

--- a/include/jni/class.hpp
+++ b/include/jni/class.hpp
@@ -1,40 +1,44 @@
 #pragma once
 
 #include <jni/functions.hpp>
+#include <jni/type.hpp>
 #include <jni/tagging.hpp>
 #include <jni/pointer_to_value.hpp>
 
 namespace jni
    {
-    template < class TheTag > class Object;
-    template < class TheTag, class... > class Constructor;
-    template < class TheTag, class > class Field;
-    template < class TheTag, class > class StaticField;
-    template < class TheTag, class > class Method;
-    template < class TheTag, class > class StaticMethod;
-
-    template < class TheTag >
-    class Class;
+    template < class TagType > class TypedObject;
+    template < class TagType, class... > class TypedConstructor;
+    template < class TagType, class > class TypedField;
+    template < class TagType, class > class TypedStaticField;
+    template < class TagType, class > class TypedMethod;
+    template < class TagType, class > class TypedStaticMethod;
 
     template < class TagType >
-    class ClassDeleter;
+    class TypedClass;
 
     template < class TagType >
-    using UniqueClass = std::unique_ptr< const Class<TagType>, ClassDeleter<TagType> >;
+    class TypedClassDeleter;
 
-    template < class TheTag >
-    class Class
+    template < class TagType >
+    using TypedUniqueClass = std::unique_ptr< const TypedClass<TagType>, TypedClassDeleter<TagType> >;
+
+    template < class Tag >
+    using Class = TypedClass< TypeFromTag<Tag> >;
+
+    template <char... Chars>
+    class TypedClass< Type<Chars...> >
        {
         private:
             jclass* clazz = nullptr;
 
         public:
-            using TagType = TheTag;
+            using TagType = Type<Chars...>;
 
-            explicit Class(std::nullptr_t = nullptr)
+            explicit TypedClass(std::nullptr_t = nullptr)
                {}
 
-            explicit Class(jclass& c)
+            explicit TypedClass(jclass& c)
                : clazz(&c)
                {}
 
@@ -44,115 +48,116 @@ namespace jni
             jclass& operator*() const { return *clazz; }
             jclass* Get() const { return clazz; }
 
-            friend bool operator==( const Class& a, const Class& b )  { return a.Get() == b.Get(); }
-            friend bool operator!=( const Class& a, const Class& b )  { return !( a == b ); }
+            friend bool operator==( const TypedClass& a, const TypedClass& b )  { return a.Get() == b.Get(); }
+            friend bool operator!=( const TypedClass& a, const TypedClass& b )  { return !( a == b ); }
 
             template < class... Args >
-            Object<TagType> New(JNIEnv& env, const Constructor<TagType, Args...>& method, const Args&... args) const
+            TypedObject<TagType> New(JNIEnv& env, const TypedConstructor<TagType, Args...>& method, const Args&... args) const
                {
-                return Object<TagType>(&NewObject(env, *clazz, method, Untag(args)...));
+                return TypedObject<TagType>(&NewObject(env, *clazz, method, Untag(args)...));
                }
 
             template < class T >
-            auto Get(JNIEnv& env, const StaticField<TagType, T>& field) const
+            auto Get(JNIEnv& env, const TypedStaticField<TagType, T>& field) const
                -> std::enable_if_t< IsPrimitive<T>::value, T >
                {
                 return jni::GetStaticField<T>(env, *clazz, field);
                }
 
             template < class T >
-            auto Get(JNIEnv& env, const StaticField<TagType, T>& field) const
+            auto Get(JNIEnv& env, const TypedStaticField<TagType, T>& field) const
                -> std::enable_if_t< !IsPrimitive<T>::value, T >
                {
                 return T(reinterpret_cast<UntaggedType<T>>(jni::GetStaticField<jobject*>(env, *clazz, field)));
                }
 
             template < class T >
-            auto Set(JNIEnv& env, const StaticField<TagType, T>& field, T value) const
+            auto Set(JNIEnv& env, const TypedStaticField<TagType, T>& field, T value) const
                -> std::enable_if_t< IsPrimitive<T>::value >
                {
                 SetStaticField<T>(env, *clazz, field, value);
                }
 
             template < class T >
-            auto Set(JNIEnv& env, const StaticField<TagType, T>& field, const T& value) const
+            auto Set(JNIEnv& env, const TypedStaticField<TagType, T>& field, const T& value) const
                -> std::enable_if_t< !IsPrimitive<T>::value >
                {
                 SetStaticField<jobject*>(env, *clazz, field, value.Get());
                }
 
             template < class R, class... Args >
-            auto Call(JNIEnv& env, const StaticMethod<TagType, R (Args...)>& method, const Args&... args) const
+            auto Call(JNIEnv& env, const TypedStaticMethod<TagType, R (Args...)>& method, const Args&... args) const
                -> std::enable_if_t< IsPrimitive<R>::value, R >
                {
                 return CallStaticMethod<R>(env, *clazz, method, Untag(args)...);
                }
 
             template < class R, class... Args >
-            auto Call(JNIEnv& env, const StaticMethod<TagType, R (Args...)>& method, const Args&... args) const
+            auto Call(JNIEnv& env, const TypedStaticMethod<TagType, R (Args...)>& method, const Args&... args) const
                -> std::enable_if_t< !IsPrimitive<R>::value, R >
                {
                 return R(reinterpret_cast<UntaggedType<R>>(CallStaticMethod<jobject*>(env, *clazz, method, Untag(args)...)));
                }
 
             template < class... Args >
-            void Call(JNIEnv& env, const StaticMethod<TagType, void (Args...)>& method, const Args&... args) const
+            void Call(JNIEnv& env, const TypedStaticMethod<TagType, void (Args...)>& method, const Args&... args) const
                {
                 CallStaticMethod<void>(env, *clazz, method, Untag(args)...);
                }
 
-            static Class Find(JNIEnv& env)
+            static TypedClass Find(JNIEnv& env)
                {
-                return Class(FindClass(env, TagType::Name()));
+                static constexpr const char name[] { Chars..., '\0' };
+                return TypedClass(FindClass(env, name));
                }
 
             template < class... Args >
-            Constructor<TagType, Args...> GetConstructor(JNIEnv& env)
+            TypedConstructor<TagType, Args...> GetConstructor(JNIEnv& env)
                {
-                return Constructor<TagType, Args...>(env, *this);
+                return TypedConstructor<TagType, Args...>(env, *this);
                }
 
             template < class T >
-            Field<TagType, T> GetField(JNIEnv& env, const char* name)
+            TypedField<TagType, T> GetField(JNIEnv& env, const char* name)
                {
-                return Field<TagType, T>(env, *this, name);
+                return TypedField<TagType, T>(env, *this, name);
                }
 
             template < class T >
-            StaticField<TagType, T> GetStaticField(JNIEnv& env, const char* name)
+            TypedStaticField<TagType, T> GetStaticField(JNIEnv& env, const char* name)
                {
-                return StaticField<TagType, T>(env, *this, name);
+                return TypedStaticField<TagType, T>(env, *this, name);
                }
 
             template < class T >
-            Method<TagType, T> GetMethod(JNIEnv& env, const char* name)
+            TypedMethod<TagType, T> GetMethod(JNIEnv& env, const char* name)
                {
-                return Method<TagType, T>(env, *this, name);
+                return TypedMethod<TagType, T>(env, *this, name);
                }
 
             template < class T >
-            StaticMethod<TagType, T> GetStaticMethod(JNIEnv& env, const char* name)
+            TypedStaticMethod<TagType, T> GetStaticMethod(JNIEnv& env, const char* name)
                {
-                return StaticMethod<TagType, T>(env, *this, name);
+                return TypedStaticMethod<TagType, T>(env, *this, name);
                }
 
-            UniqueClass<TagType> NewGlobalRef(JNIEnv& env) const
+            TypedUniqueClass<TagType> NewGlobalRef(JNIEnv& env) const
                {
-                return Seize(env, Class(*jni::NewGlobalRef(env, clazz).release()));
+                return Seize(env, TypedClass(*jni::NewGlobalRef(env, clazz).release()));
                }
        };
 
-    template < class TagType >
-    class ClassDeleter
+    template <char... Chars>
+    class TypedClassDeleter< Type<Chars...> >
        {
         private:
             JNIEnv* env = nullptr;
 
         public:
-            using pointer = PointerToValue< Class<TagType> >;
+            using pointer = PointerToValue< TypedClass< Type<Chars...> > >;
 
-            ClassDeleter() = default;
-            ClassDeleter(JNIEnv& e) : env(&e) {}
+            TypedClassDeleter() = default;
+            TypedClassDeleter(JNIEnv& e) : env(&e) {}
 
             void operator()(pointer p) const
                {
@@ -165,8 +170,8 @@ namespace jni
        };
 
     template < class TagType >
-    UniqueClass<TagType> Seize(JNIEnv& env, Class<TagType>&& clazz)
+    TypedUniqueClass<TagType> Seize(JNIEnv& env, TypedClass<TagType>&& clazz)
        {
-        return UniqueClass<TagType>(PointerToValue<Class<TagType>>(std::move(clazz)), ClassDeleter<TagType>(env));
+        return TypedUniqueClass<TagType>(PointerToValue<TypedClass<TagType>>(std::move(clazz)), TypedClassDeleter<TagType>(env));
        };
    }

--- a/include/jni/constructor.hpp
+++ b/include/jni/constructor.hpp
@@ -4,12 +4,16 @@
 
 namespace jni
    {
+
+    template < class Tag, class... Args >
+    using Constructor = TypedConstructor< TypeFromTag<Tag>, Args... >;
+
     template < class TagType, class... Args >
-    class Constructor : public Method<TagType, void (Args...)>
+    class TypedConstructor : public TypedMethod<TagType, void (Args...)>
        {
         public:
-            Constructor(JNIEnv& env, const Class<TagType>& clazz)
-               : Method<TagType, void (Args...)>(env, clazz, "<init>")
+            TypedConstructor(JNIEnv& env, const TypedClass<TagType>& clazz)
+               : TypedMethod<TagType, void (Args...)>(env, clazz, "<init>")
                {}
        };
    }

--- a/include/jni/field.hpp
+++ b/include/jni/field.hpp
@@ -8,16 +8,22 @@
 
 namespace jni
    {
-    template < class TheTag, class T >
-    class Field
+    template < class TagType, class T >
+    class TypedField;
+
+    template < class Tag, class T >
+    using Field = TypedField< TypeFromTag<Tag>, T >;
+
+    template <char... Chars, class T>
+    class TypedField< Type<Chars...>, T >
        {
         private:
             jfieldID& field;
 
         public:
-            using TagType = TheTag;
+            using TagType = Type<Chars...>;
 
-            Field(JNIEnv& env, const Class<TagType>& clazz, const char* name)
+            TypedField(JNIEnv& env, const TypedClass<TagType>& clazz, const char* name)
               : field(GetFieldID(env, clazz, name, TypeSignature<T>()()))
                {}
 

--- a/include/jni/method.hpp
+++ b/include/jni/method.hpp
@@ -8,19 +8,22 @@
 
 namespace jni
    {
-    template < class TheTag, class >
-    class Method;
+    template < class TagType, class >
+    class TypedMethod;
 
-    template < class TheTag, class R, class... Args >
-    class Method< TheTag, R (Args...) >
+    template < class Tag, class R, class... Args >
+    using Method = TypedMethod< TypeFromTag<Tag>, R (Args...) >;
+
+    template < char... Chars, class R, class... Args >
+    class TypedMethod< Type<Chars...>, R (Args...) >
        {
         private:
             jmethodID& method;
 
         public:
-            using TagType = TheTag;
+            using TagType = Type<Chars...>;
 
-            Method(JNIEnv& env, const Class<TagType>& clazz, const char* name)
+            TypedMethod(JNIEnv& env, const TypedClass<TagType>& clazz, const char* name)
               : method(GetMethodID(env, clazz, name, TypeSignature<R (Args...)>()()))
                {}
 

--- a/include/jni/static_field.hpp
+++ b/include/jni/static_field.hpp
@@ -8,16 +8,22 @@
 
 namespace jni
    {
-    template < class TheTag, class T >
-    class StaticField
+    template < class TagType, class T >
+    class TypedStaticField;
+
+    template < class Tag, class T >
+    using StaticField = TypedStaticField< TypeFromTag<Tag>, T >;
+
+    template <char... Chars, class T>
+    class TypedStaticField< Type<Chars...>, T >
        {
         private:
             jfieldID& field;
 
         public:
-            using TagType = TheTag;
+            using TagType = Type<Chars...>;
 
-            StaticField(JNIEnv& env, const Class<TagType>& clazz, const char* name)
+            TypedStaticField(JNIEnv& env, const TypedClass<TagType>& clazz, const char* name)
               : field(GetStaticFieldID(env, clazz, name, TypeSignature<T>()()))
                {}
 

--- a/include/jni/static_method.hpp
+++ b/include/jni/static_method.hpp
@@ -8,19 +8,22 @@
 
 namespace jni
    {
-    template < class TheTag, class >
-    class StaticMethod;
+    template < class TagType, class >
+    class TypedStaticMethod;
 
-    template < class TheTag, class R, class... Args >
-    class StaticMethod< TheTag, R (Args...) >
+    template < class Tag, class R, class... Args >
+    using StaticMethod = TypedStaticMethod< TypeFromTag<Tag>, R (Args...) >;
+
+    template <char... Chars, class R, class... Args>
+    class TypedStaticMethod< Type<Chars...>, R (Args...) >
        {
         private:
             jmethodID& method;
 
         public:
-            using TagType = TheTag;
+            using TagType = Type<Chars...>;
 
-            StaticMethod(JNIEnv& env, const Class<TagType>& clazz, const char* name)
+            TypedStaticMethod(JNIEnv& env, const TypedClass<TagType>& clazz, const char* name)
               : method(GetStaticMethodID(env, clazz, name, TypeSignature<R (Args...)>()()))
                {}
 

--- a/include/jni/string.hpp
+++ b/include/jni/string.hpp
@@ -13,7 +13,7 @@ namespace jni
     struct StringTag { static constexpr auto Name() { return "java/lang/String"; } };
 
     template <>
-    struct UntaggedObjectType<StringTag> { using Type = jstring; };
+    struct TypedUntaggedObjectType< TypeFromTag<StringTag> > { using Type = jstring; };
 
     using String = Object<StringTag>;
 

--- a/include/jni/type.hpp
+++ b/include/jni/type.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <type_traits>
+
+namespace jni
+   {
+    template < char... Chars > struct Type {};
+
+    template < class Tag >
+    struct TypeFactory {
+    private:
+        static constexpr std::size_t Size(char const* str, std::size_t count = 0) {
+            return (str[0] == '\0') ? count : Size(str + 1, count + 1);
+        }
+
+        template <std::size_t... I>
+        static Type<Tag::Name()[I]...> ExpandType(std::index_sequence<I...>);
+
+    public:
+        using TagType = decltype(ExpandType(std::make_index_sequence<Size(Tag::Name())>{}));
+    };
+
+    template < class Tag >
+    using TypeFromTag = typename TypeFactory<Tag>::TagType;
+   }

--- a/include/jni/type_signature.hpp
+++ b/include/jni/type_signature.hpp
@@ -21,13 +21,13 @@ namespace jni
     template <> struct TypeSignature< jdouble  > { const char * operator()() const { return "D"; } };
     template <> struct TypeSignature< void     > { const char * operator()() const { return "V"; } };
 
-    template < class TheTag >
-    struct TypeSignature< Object<TheTag> >
+    template < char... Chars >
+    struct TypeSignature< TypedObject< Type<Chars...> > >
        {
         const char * operator()() const
            {
-            static std::string value { std::string("L") + TheTag::Name() + ";" };
-            return value.c_str();
+            static constexpr const char value[] = { 'L', Chars..., ';', '\0' };
+            return value;
            }
        };
 

--- a/test/high_level.cpp
+++ b/test/high_level.cpp
@@ -63,7 +63,7 @@ int main()
 
     env.functions->FindClass = [] (JNIEnv*, const char* name) -> jclass
        {
-        assert(name == Test::Name());
+        assert(strcmp(name, Test::Name()) == 0);
         return Unwrap(classValue.Ptr());
        };
 


### PR DESCRIPTION
Convert Tag types to `jni::Tag<char...>` types before instantiating the Object/Class/Method/Constructor/StaticMethod/Field/StaticField types. This removes a source of error where two Tag types returning the same string yielded incompatible Object/... types. Instead of templating these by Tag, we generate a `jni::Tag<char...>` type like `jni::Type<'j', 'a', 'v', 'a', '/', 'l', 'a', 'n', 'g', '/', 'O', 'b', 'j', 'e', 'c', 't'>`, which means that two distinct Tags produce the identical type if the returned string is identical.

The primary change is the rename from `Object` to `TypedObject`, with a type alias from `Object` => `TypedObject`. Then, I changed `TypeObject` to only have a specialization when the `TagType` is a `jni::Tag`, and the type alias automatically converts the tag to a `Type` type. Same applies to the other entities.

This means that it should be largely backwards-compatible.