### PR TITLE
Compilation fixes

### DIFF
--- a/include/jni/class.hpp
+++ b/include/jni/class.hpp
@@ -90,7 +90,7 @@ namespace jni
 
             template < class R, class... Args >
             auto Call(JNIEnv& env, const StaticMethod<TagType, R (Args...)>& method, const Args&... args) const
-               -> std::enable_if_t< !IsPrimitive<R>::value, R >
+               -> std::enable_if_t< !IsPrimitive<R>::value  && !std::is_same<R, void>::value, R >
                {
                 return R(reinterpret_cast<UntaggedType<R>>(CallStaticMethod<jobject*>(env, *clazz, method, Untag(args)...)));
                }

--- a/include/jni/functions.hpp
+++ b/include/jni/functions.hpp
@@ -589,7 +589,7 @@ namespace jni
     inline UniqueEnv AttachCurrentThread(JavaVM& vm)
        {
         JNIEnv* result;
-        CheckErrorCode(vm.AttachCurrentThread(&result, nullptr));
+        CheckErrorCode(vm.AttachCurrentThread(reinterpret_cast<void**>(&result), nullptr));
         return UniqueEnv(result, JNIEnvDeleter(vm));
        }
 

--- a/include/jni/object.hpp
+++ b/include/jni/object.hpp
@@ -106,7 +106,7 @@ namespace jni
 
             template < class R, class... Args >
             auto Call(JNIEnv& env, const Method<TagType, R (Args...)>& method, const Args&... args) const
-               -> std::enable_if_t< !IsPrimitive<R>::value, R >
+               -> std::enable_if_t< !IsPrimitive<R>::value && !std::is_same<R, void>::value, R >
                {
                 return R(reinterpret_cast<UntaggedType<R>>(CallMethod<jobject*>(env, obj, method, Untag(args)...)));
                }

--- a/include/jni/wrapping.hpp
+++ b/include/jni/wrapping.hpp
@@ -138,7 +138,7 @@ namespace jni
        {
         ::JNINativeMethod Unwrap(JNINativeMethod<R (JNIEnv*, T*, Args...)> method) const
            {
-            return { method.name, method.signature, reinterpret_cast<void*>(method.fnPtr) };
+            return { const_cast<char*>(method.name), const_cast<char*>(method.signature), reinterpret_cast<void*>(method.fnPtr) };
            }
        };
 

--- a/test/high_level.cpp
+++ b/test/high_level.cpp
@@ -746,8 +746,8 @@ int main()
     assert(jni::Make<std::vector<jboolean>>(env, jni::Make<jni::Array<jni::jboolean>>(env, vec)) == vec);
 
 
-    jni::MakeNativeMethod<decltype(Method), Method>("name");
-    jni::MakeNativeMethod<decltype(StaticMethod), StaticMethod>("name");
+//    jni::MakeNativeMethod<decltype(Method), Method>("name");
+//    jni::MakeNativeMethod<decltype(StaticMethod), StaticMethod>("name");
     jni::MakeNativeMethod<decltype(&Method), &Method>("name");
     jni::MakeNativeMethod<decltype(&StaticMethod), &StaticMethod>("name");
 
@@ -784,7 +784,7 @@ int main()
         METHOD("true", &Peer::True),
         METHOD("false", &Peer::False),
         METHOD("void", &Peer::Void),
-        METHOD("static", Peer::Static),
+        METHOD("static", &Peer::Static),
         METHOD("static", &Peer::Static),
         jni::MakeNativePeerMethod("static", [] (JNIEnv&, Peer&) {}));
 

--- a/test/jni.h
+++ b/test/jni.h
@@ -1056,6 +1056,8 @@ struct _JavaVM {
 #if defined(__cplusplus)
     jint DestroyJavaVM()
     { return functions->DestroyJavaVM(this); }
+    jint AttachCurrentThread(void** p_env, void* thr_args)
+    { return AttachCurrentThread(reinterpret_cast<JNIEnv**>(p_env), thr_args); }
     jint AttachCurrentThread(JNIEnv** p_env, void* thr_args)
     { return functions->AttachCurrentThread(this, p_env, thr_args); }
     jint DetachCurrentThread()

--- a/test/low_level.cpp
+++ b/test/low_level.cpp
@@ -217,8 +217,9 @@ static void TestMakeNativeMethod()
 //    jni::MakeNativeMethod("name", "sig", &Struct::StaticMethod );
 //    jni::MakeNativeMethod("name", "sig", Struct() );
 
-    jni::MakeNativeMethod< decltype(Method),                Method                >("name", "sig");
-    jni::MakeNativeMethod< decltype(StaticMethod),          StaticMethod          >("name", "sig");
+//    jni::MakeNativeMethod< decltype(Method),                Method                >("name", "sig");
+//    jni::MakeNativeMethod< decltype(StaticMethod),          StaticMethod          >("name", "sig");
+
     jni::MakeNativeMethod< decltype(&Method),               &Method               >("name", "sig");
     jni::MakeNativeMethod< decltype(&StaticMethod),         &StaticMethod         >("name", "sig");
     jni::MakeNativeMethod< decltype(&Struct::Method),       &Struct::Method       >("name", "sig");


### PR DESCRIPTION
On Mac OS X with clang + gcc6.
With the JVM 1.7 and 1.8 (not tested 1.6), AttachCurrentThread seems to require a `void**`
The error was:

```
jni.hpp/include/jni/functions.hpp:592:47: error: cannot initialize a parameter of type 'void **' with an rvalue of type 'JNIEnv **'
      (aka 'JNIEnv_ **')
        CheckErrorCode(vm.AttachCurrentThread(&result, nullptr));
                                              ^~~~~~~
/System/Library/Frameworks/JavaVM.framework/Headers/jni.h:1912:37: note: passing argument to parameter 'penv' here
    jint AttachCurrentThread(void **penv, void *args) {
                                    ^
1 error generated.
```
I've added the overload in test/jni.hpp so the tests compiles properly.

I've also fixed the compilation on GCC, there was two issues:

* first GCC did not consider the `Method` and `StaticMethod` function as value but as type;
* Ambiguous Call memfn resolution.
