### PR TITLE
Minor improvement by adding a typedef for the FieldType in Field class

### DIFF
--- a/include/jni/field.hpp
+++ b/include/jni/field.hpp
@@ -16,7 +16,7 @@ namespace jni
 
         public:
             using TagType = TheTag;
-			using FieldType = T;
+            using FieldType = T;
 
             Field(JNIEnv& env, const Class<TagType>& clazz, const char* name)
               : field(GetFieldID(env, clazz, name, TypeSignature<T>()()))

--- a/include/jni/field.hpp
+++ b/include/jni/field.hpp
@@ -16,6 +16,7 @@ namespace jni
 
         public:
             using TagType = TheTag;
+			using FieldType = T;
 
             Field(JNIEnv& env, const Class<TagType>& clazz, const char* name)
               : field(GetFieldID(env, clazz, name, TypeSignature<T>()()))


### PR DESCRIPTION
Useful type def when writing something like:

```
template <class ClassTag>
using TIntField = jni::Field<ClassTag, jni::jint>;
using TIntField = TIntField<MyTagType>;
TIntField myField(uniqueClass->GetField<TIntField::FieldType>(env, "fieldName"));
```