### PR TITLE
Support Array<jbyte> <-> std::string conversions

### DIFF
--- a/include/jni/array.hpp
+++ b/include/jni/array.hpp
@@ -180,4 +180,22 @@ namespace jni
         SetArrayRegion(env, *result, 0, array);
         return result;
        }
+
+    inline
+    std::string MakeAnything(ThingToMake<std::string>, JNIEnv& env, const Array<jbyte>& array)
+       {
+        NullCheck(env, array.Get());
+        std::string result;
+        result.resize(GetArrayLength(env, *array));
+        GetArrayRegion(env, *array, 0, result.size(), reinterpret_cast<jbyte*>(&result[0]));
+        return result;
+       }
+
+    inline
+    Array<jbyte> MakeAnything(ThingToMake<Array<jbyte>>, JNIEnv& env, const std::string& string)
+       {
+        Array<jbyte> result(&NewArray<jbyte>(env, string.size()));
+        SetArrayRegion(env, *result, 0, string.size(), reinterpret_cast<const jbyte*>(&string[0]));
+        return result;
+       }
    }


### PR DESCRIPTION
Make jni fields/methods copyable.

Array<jbyte> <-> std::string conversions are needed to push protocol buffers
across jni boundaries by serializing and deserializing.

Copyable Method/Fields are needed so that these can be stored in global statics.