### PR TITLE
Test for assigning Method/Fields to globals.

### DIFF
--- a/include/jni/field.hpp
+++ b/include/jni/field.hpp
@@ -12,16 +12,20 @@ namespace jni
     class Field
        {
         private:
-            jfieldID& field;
+            jfieldID* field;
 
         public:
             using TagType = TheTag;
             using FieldType = T;
 
-            Field(JNIEnv& env, const Class<TagType>& clazz, const char* name)
-              : field(GetFieldID(env, clazz, name, TypeSignature<T>()()))
+            Field()
+              : field(nullptr)
                {}
 
-            operator jfieldID&() const { return field; }
+            Field(JNIEnv& env, const Class<TagType>& clazz, const char* name)
+              : field(&GetFieldID(env, clazz, name, TypeSignature<T>()()))
+               {}
+
+            operator jfieldID&() const { return *field; }
        };
    }

--- a/include/jni/method.hpp
+++ b/include/jni/method.hpp
@@ -15,17 +15,21 @@ namespace jni
     class Method< TheTag, R (Args...) >
        {
         private:
-            jmethodID& method;
+            jmethodID* method;
 
         public:
             using TagType = TheTag;
             using MethodType = R (Args...);
             using ReturnType = R;
 
-            Method(JNIEnv& env, const Class<TagType>& clazz, const char* name)
-              : method(GetMethodID(env, clazz, name, TypeSignature<R (Args...)>()()))
+            Method()
+              : method(nullptr)
                {}
 
-            operator jmethodID&() const { return method; }
+            Method(JNIEnv& env, const Class<TagType>& clazz, const char* name)
+              : method(&GetMethodID(env, clazz, name, TypeSignature<R (Args...)>()()))
+               {}
+
+            operator jmethodID&() const { return *method; }
        };
    }

--- a/include/jni/static_field.hpp
+++ b/include/jni/static_field.hpp
@@ -12,16 +12,20 @@ namespace jni
     class StaticField
        {
         private:
-            jfieldID& field;
+            jfieldID* field;
 
         public:
             using TagType = TheTag;
             using FieldType = T;
 
-            StaticField(JNIEnv& env, const Class<TagType>& clazz, const char* name)
-              : field(GetStaticFieldID(env, clazz, name, TypeSignature<T>()()))
+            StaticField()
+              : field(nullptr)
                {}
 
-            operator jfieldID&() const { return field; }
+            StaticField(JNIEnv& env, const Class<TagType>& clazz, const char* name)
+              : field(&GetStaticFieldID(env, clazz, name, TypeSignature<T>()()))
+               {}
+
+            operator jfieldID&() const { return *field; }
        };
    }

--- a/include/jni/static_method.hpp
+++ b/include/jni/static_method.hpp
@@ -15,17 +15,21 @@ namespace jni
     class StaticMethod< TheTag, R (Args...) >
        {
         private:
-            jmethodID& method;
+            jmethodID* method;
 
         public:
             using TagType = TheTag;
             using MethodType = R (Args...);
             using ReturnType = R;
 
-            StaticMethod(JNIEnv& env, const Class<TagType>& clazz, const char* name)
-              : method(GetStaticMethodID(env, clazz, name, TypeSignature<R (Args...)>()()))
+            StaticMethod()
+              : method(nullptr)
                {}
 
-            operator jmethodID&() const { return method; }
+            StaticMethod(JNIEnv& env, const Class<TagType>& clazz, const char* name)
+              : method(&GetStaticMethodID(env, clazz, name, TypeSignature<R (Args...)>()()))
+               {}
+
+            operator jmethodID&() const { return *method; }
        };
    }

--- a/test/high_level.cpp
+++ b/test/high_level.cpp
@@ -23,6 +23,14 @@ namespace
        };
    }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wglobal-constructors"
+jni::StaticMethod<Test, void()> g_voidVoidStaticMethod;
+jni::Method<Test, void()> g_voidVoidMethod;
+jni::StaticField<Test, jni::jboolean> g_booleanStaticField;
+jni::Field<Test, jni::jboolean> g_booleanField;
+#pragma GCC diagnostic pop
+
 int main()
    {
     /// TypeSignature
@@ -236,6 +244,7 @@ int main()
         assert(value == jni::Unwrap(objectValue.Ptr()));
        };
 
+    g_booleanStaticField = testClass.GetStaticField<jni::jboolean>(env, booleanFieldName);
     auto booleanStaticField = testClass.GetStaticField<jni::jboolean>(env, booleanFieldName);
     auto objectStaticField  = testClass.GetStaticField<jni::Object<Test>>(env, objectFieldName);
 
@@ -297,6 +306,7 @@ int main()
            }
        };
 
+    g_booleanField = testClass.GetField<jni::jboolean>(env, booleanFieldName);
     auto booleanField = testClass.GetField<jni::jboolean>(env, booleanFieldName);
     auto objectField  = testClass.GetField<jni::Object<Test>>(env, objectFieldName);
     auto stringField  = testClass.GetField<jni::String>(env, stringFieldName);
@@ -401,6 +411,7 @@ int main()
         va_end(args);
        };
 
+    g_voidVoidStaticMethod = testClass.GetStaticMethod<void ()>(env, voidMethodName);
     auto voidVoidStaticMethod    = testClass.GetStaticMethod<void ()>(env, voidMethodName);
     auto voidBooleanStaticMethod = testClass.GetStaticMethod<void (jni::jboolean)>(env, voidMethodName);
     auto voidObjectStaticMethod  = testClass.GetStaticMethod<void (jni::Object<Test>)>(env, voidMethodName);
@@ -501,6 +512,7 @@ int main()
         va_end(args);
        };
 
+    g_voidVoidMethod    = testClass.GetMethod<void ()>(env, voidMethodName);
     auto voidVoidMethod    = testClass.GetMethod<void ()>(env, voidMethodName);
     auto voidBooleanMethod = testClass.GetMethod<void (jni::jboolean)>(env, voidMethodName);
     auto voidObjectMethod  = testClass.GetMethod<void (jni::Object<Test>)>(env, voidMethodName);


### PR DESCRIPTION
**For discussion only.**

Note that this also would need default constructors.  So declaring as extern for now to produce compilation errors seen.

Compilation errors that I see:
```
[param@param-mac:~/jni.hpp]$ make test
c++ -o tst  -Iinclude --std=c++14 -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-exit-time-destructors -Werror -Itest/android -g -Wno-padded test/low_level.cpp && ./tst
c++ -o tst  -Iinclude --std=c++14 -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-exit-time-destructors -Werror -Itest/android -g -Wno-padded test/high_level.cpp && ./tst
test/high_level.cpp:244:26: error: object of type 'jni::StaticField<(anonymous namespace)::Test, unsigned char>' cannot be
      assigned because its copy assignment operator is implicitly deleted
    g_booleanStaticField = testClass.GetStaticField<jni::jboolean>(env, booleanFieldName);
                         ^
include/jni/static_field.hpp:15:23: note: copy assignment operator of 'StaticField<(anonymous namespace)::Test, unsigned
      char>' is implicitly deleted because field 'field' is of reference type 'jfieldID &' (aka '_jfieldID &')
            jfieldID& field;
                      ^
test/high_level.cpp:306:20: error: object of type 'jni::Field<(anonymous namespace)::Test, unsigned char>' cannot be
      assigned because its copy assignment operator is implicitly deleted
    g_booleanField = testClass.GetField<jni::jboolean>(env, booleanFieldName);
                   ^
include/jni/field.hpp:15:23: note: copy assignment operator of 'Field<(anonymous namespace)::Test, unsigned char>' is
      implicitly deleted because field 'field' is of reference type 'jfieldID &' (aka '_jfieldID &')
            jfieldID& field;
                      ^
test/high_level.cpp:411:28: error: object of type 'jni::StaticMethod<(anonymous namespace)::Test, void ()>' cannot be
      assigned because its copy assignment operator is implicitly deleted
    g_voidVoidStaticMethod = testClass.GetStaticMethod<void ()>(env, voidMethodName);
                           ^
include/jni/static_method.hpp:18:24: note: copy assignment operator of
      'StaticMethod<(anonymous namespace)::Test, void ()>' is implicitly deleted because field 'method' is of reference
      type 'jmethodID &' (aka '_jmethodID &')
            jmethodID& method;
                       ^
test/high_level.cpp:544:5: error: use of undeclared identifier 'g_booleanVoidMethod'; did you mean 'booleanVoidMethodID'?
    g_booleanVoidMethod    = testClass.GetMethod<jni::jboolean ()>(env, booleanMethodName);
    ^~~~~~~~~~~~~~~~~~~
    booleanVoidMethodID
test/high_level.cpp:325:37: note: 'booleanVoidMethodID' declared here
    static Testable<jni::jmethodID> booleanVoidMethodID;
                                    ^
test/high_level.cpp:544:28: error: no viable overloaded '='
    g_booleanVoidMethod    = testClass.GetMethod<jni::jboolean ()>(env, booleanMethodName);
    ~~~~~~~~~~~~~~~~~~~    ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test/test.hpp:8:8: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from
      'Method<TagType, unsigned char ()>' (aka 'Method<(anonymous namespace)::Test, unsigned char ()>') to
      'const Testable<_jmethodID>' for 1st argument
struct Testable
       ^
test/test.hpp:8:8: note: candidate function (the implicit move assignment operator) not viable: no known conversion from
      'Method<TagType, unsigned char ()>' (aka 'Method<(anonymous namespace)::Test, unsigned char ()>') to
      'Testable<_jmethodID>' for 1st argument
5 errors generated.
make: *** [test] Error 1
```