### PR TITLE
Add deleters that attach or get the JNIEnv

### DIFF
--- a/include/jni/advanced_ownership.hpp
+++ b/include/jni/advanced_ownership.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <jni/functions.hpp>
+
+namespace jni
+   {
+    // A deleter that gets the JNIEnv via GetEnv, rather than storing the value passed to the constructor.
+    // The deleting thread must have a JVM attachment.
+    //
+    // Useful when deletion will happen on an auxiliary thread, particularly the finalizer thread. In such
+    // cases, you may use one of the following:
+    //
+    //   low-level: UniqueGlobalRef<jobject, EnvGettingDeleter> and NewGlobalRef<EnvGettingDeleter>
+    //   high-level: Global<Object<Tag>, EnvGettingDeleter> and obj.NewGlobalRef<EnvGettingDeleter>
+    //
+    template < RefDeletionMethod DeleteRef >
+    class EnvGettingDeleter
+       {
+        private:
+            JavaVM* vm = nullptr;
+
+        public:
+            EnvGettingDeleter() = default;
+            EnvGettingDeleter(JNIEnv& e) : vm(&GetJavaVM(e)) {}
+
+            void operator()(jobject* p) const
+               {
+                if (p)
+                   {
+                    assert(vm);
+                    (GetEnv(*vm).*DeleteRef)(Unwrap(p));
+                   }
+               }
+       };
+
+    // A deleter that first tries GetEnv, but falls back to AttachCurrentThread if a JVM is not already attached.
+    // In the latter case, it detaches after deleting the reference.
+    //
+    // Useful when deletion will happen on an auxiliary thread which may or may not have a JVM attachment. In such
+    // cases, you may use one of the following:
+    //
+    //   low-level: UniqueGlobalRef<jobject, EnvAttachingDeleter> and NewGlobalRef<EnvAttachingDeleter>
+    //   high-level: Global<Object<Tag>, EnvAttachingDeleter> and obj.NewGlobalRef<EnvAttachingDeleter>
+    //
+    template < RefDeletionMethod DeleteRef >
+    class EnvAttachingDeleter
+       {
+        private:
+            JavaVM* vm = nullptr;
+
+        public:
+            EnvAttachingDeleter() = default;
+            EnvAttachingDeleter(JNIEnv& e) : vm(&GetJavaVM(e)) {}
+
+            void operator()(jobject* p) const
+               {
+                if (p)
+                   {
+                    assert(vm);
+                    JNIEnv* env = nullptr;
+                    jint err = vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_1);
+                    if (err == JNI_OK)
+                       {
+                        (env->*DeleteRef)(Unwrap(p));
+                       }
+                    else if (err == JNI_EDETACHED)
+                       {
+                        ((*AttachCurrentThread(*vm)).*DeleteRef)(Unwrap(p));
+                       }
+                    else
+                       {
+                        CheckErrorCode(err);
+                       }
+                   }
+               }
+       };
+   }

--- a/include/jni/array.hpp
+++ b/include/jni/array.hpp
@@ -87,9 +87,10 @@ namespace jni
                 return Array<E>(&NewArray<E>(env, length));
                }
 
-            Global<Array<E>> NewGlobalRef(JNIEnv& env) const
+            template < template < RefDeletionMethod > class Deleter = DefaultRefDeleter >
+            Global<Array<E>, Deleter> NewGlobalRef(JNIEnv& env) const
                {
-                return SeizeGlobal(env, Array(jni::NewGlobalRef(env, array).release()));
+                return SeizeGlobal<Deleter>(env, Array(jni::NewGlobalRef(env, array).release()));
                }
        };
 
@@ -159,9 +160,10 @@ namespace jni
                 return Array<Object<TheTag>>(&NewObjectArray(env, length, Class<TheTag>::Singleton(env), initialElement.Get()));
                }
 
-            Global<Array<Object<TheTag>>> NewGlobalRef(JNIEnv& env) const
+            template < template < RefDeletionMethod > class Deleter = DefaultRefDeleter >
+            Global<Array<Object<TheTag>>, Deleter> NewGlobalRef(JNIEnv& env) const
                {
-                return SeizeGlobal(env, Array(jni::NewGlobalRef(env, array).release()));
+                return SeizeGlobal<Deleter>(env, Array(jni::NewGlobalRef(env, array).release()));
                }
       };
 

--- a/include/jni/class.hpp
+++ b/include/jni/class.hpp
@@ -147,9 +147,10 @@ namespace jni
                 return StaticMethod<TagType, T>(env, *this, name);
                }
 
-            Global<Class<TagType>> NewGlobalRef(JNIEnv& env) const
+            template < template < RefDeletionMethod > class Deleter = DefaultRefDeleter >
+            Global<Class<TagType>, Deleter> NewGlobalRef(JNIEnv& env) const
                {
-                return SeizeGlobal(env, Class(*jni::NewGlobalRef(env, clazz).release()));
+                return SeizeGlobal<Deleter>(env, Class(*jni::NewGlobalRef(env, clazz).release()));
                }
        };
    }

--- a/include/jni/jni.hpp
+++ b/include/jni/jni.hpp
@@ -20,3 +20,4 @@
 #include <jni/static_field.hpp>
 #include <jni/native_method.hpp>
 #include <jni/boxing.hpp>
+#include <jni/advanced_ownership.hpp>

--- a/include/jni/jni.hpp
+++ b/include/jni/jni.hpp
@@ -21,3 +21,4 @@
 #include <jni/native_method.hpp>
 #include <jni/boxing.hpp>
 #include <jni/advanced_ownership.hpp>
+#include <jni/weak_reference.hpp>

--- a/include/jni/object.hpp
+++ b/include/jni/object.hpp
@@ -132,14 +132,16 @@ namespace jni
                 CallNonvirtualMethod<void>(env, obj, clazz, method, Untag(args)...);
                }
 
-            Global<Object<TagType>> NewGlobalRef(JNIEnv& env) const
+            template < template < RefDeletionMethod > class Deleter = DefaultRefDeleter >
+            Global<Object<TagType>, Deleter> NewGlobalRef(JNIEnv& env) const
                {
-                return SeizeGlobal(env, Object(jni::NewGlobalRef(env, obj).release()));
+                return SeizeGlobal<Deleter>(env, Object(jni::NewGlobalRef(env, obj).release()));
                }
 
-            Weak<Object<TagType>> NewWeakGlobalRef(JNIEnv& env) const
+            template < template < RefDeletionMethod > class Deleter = DefaultRefDeleter >
+            Weak<Object<TagType>, Deleter> NewWeakGlobalRef(JNIEnv& env) const
                {
-                return SeizeWeak(env, Object(jni::NewWeakGlobalRef(env, obj).release()));
+                return SeizeWeak<Deleter>(env, Object(jni::NewWeakGlobalRef(env, obj).release()));
                }
 
             Local<Object<TagType>> NewLocalRef(JNIEnv& env) const

--- a/include/jni/unique_pointerlike.hpp
+++ b/include/jni/unique_pointerlike.hpp
@@ -129,6 +129,10 @@ namespace jni
 
     // Attempt to promote a weak reference to a strong one. Returns an empty result
     // if the weak reference has expired.
+    //
+    // Beware that the semantics of JNI weak references are weaker than is typically
+    // desired: a JNI weak reference may still be promoted to a non-null strong reference
+    // even during finalization. Consider using jni::WeakReference<T> instead.
     template < template < RefDeletionMethod > class Deleter, class T, template < RefDeletionMethod > class WeakDeleter >
     Global<T, Deleter> NewGlobal(JNIEnv& env, const Weak<T, WeakDeleter>& t)
        {
@@ -146,6 +150,10 @@ namespace jni
 
     // Attempt to promote a weak reference to a strong one. Returns an empty result
     // if the weak reference has expired.
+    //
+    // Beware that the semantics of JNI weak references are weaker than is typically
+    // desired: a JNI weak reference may still be promoted to a non-null strong reference
+    // even during finalization. Consider using jni::WeakReference<T> instead.
     template < class T, template < RefDeletionMethod > class WeakDeleter >
     Local<T> NewLocal(JNIEnv& env, const Weak<T, WeakDeleter>& t)
        {

--- a/include/jni/weak_reference.hpp
+++ b/include/jni/weak_reference.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <jni/class.hpp>
+#include <jni/object.hpp>
+
+namespace jni
+   {
+    struct WeakReferenceTag { static constexpr auto Name() { return "java/lang/ref/WeakReference"; } };
+
+    // Wraps a JNI global reference to a java.lang.ref.WeakReference, producing an ownership class
+    // similar to jni::Weak<T> (JNI's weak global reference), but with more reliable promotion semantics.
+    // Whereas a JNI weak global reference may still be promoted to a strong reference even during
+    // finalization, leading to potential use-after-free errors, a WeakReference cannot.
+    template < class T, template < RefDeletionMethod > class Deleter = DefaultRefDeleter >
+    class WeakReference
+       {
+        private:
+            Global<Object<WeakReferenceTag>, Deleter> reference;
+
+        public:
+            WeakReference(JNIEnv& env, T referent)
+               {
+                static auto klass = Class<WeakReferenceTag>::Singleton(env);
+                static auto constructor = klass.GetConstructor<Object<>>(env);
+                reference = klass.New(env, constructor, Object<>(referent.Get())).template NewGlobalRef<Deleter>(env);
+               }
+
+            Local<T> get(JNIEnv& env)
+               {
+                if (!reference)
+                   {
+                    return Local<T>();
+                   }
+
+                static auto klass = Class<WeakReferenceTag>::Singleton(env);
+                static auto get = klass.template GetMethod<Object<> ()>(env, "get");
+                return SeizeLocal(env, T(reinterpret_cast<UntaggedType<T>>(reference->Call(env, get).Get())));
+               }
+       };
+   }


### PR DESCRIPTION
These are useful when the deletion will happen on an auxiliary thread, such as the finalizer thread.

This will replace https://github.com/mapbox/mapbox-gl-native/blob/a90e2f3a2c7d5cadd857ef65922ec8b1b70de964/platform/android/src/jni/generic_global_ref_deleter.hpp, and is also needed to fix a Mapbox internal issue.