### PR TITLE
Add overwritable <jni/string_conversion.hpp>

### DIFF
--- a/include/jni/native_method.hpp
+++ b/include/jni/native_method.hpp
@@ -10,8 +10,6 @@
 #include <exception>
 #include <type_traits>
 
-#include <iostream>
-
 namespace jni
    {
     template < class M, class Enable = void >

--- a/include/jni/string.hpp
+++ b/include/jni/string.hpp
@@ -4,9 +4,7 @@
 #include <jni/array.hpp>
 #include <jni/make.hpp>
 #include <jni/npe.hpp>
-
-#include <locale>
-#include <codecvt>
+#include <jni/string_conversion.hpp>
 
 namespace jni
    {
@@ -22,8 +20,7 @@ namespace jni
 
     inline std::string MakeAnything(ThingToMake<std::string>, JNIEnv& env, const String& string)
        {
-        return std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>()
-            .to_bytes(Make<std::u16string>(env, string));
+        return convertUTF16ToUTF8(Make<std::u16string>(env, string));
        }
 
     inline Local<String> MakeAnything(ThingToMake<String>, JNIEnv& env, const std::u16string& string)
@@ -33,7 +30,6 @@ namespace jni
 
     inline Local<String> MakeAnything(ThingToMake<String>, JNIEnv& env, const std::string& string)
        {
-        return Make<String>(env, std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>()
-            .from_bytes(string));
+        return Make<String>(env, convertUTF8ToUTF16(string));
        }
    }

--- a/include/jni/string_conversion.hpp
+++ b/include/jni/string_conversion.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+// If you want to supply your own UTF-8 <-> UTF-16 conversion routines, create a header file 
+// that can be found at <jni/string_conversion.hpp> and will be found first in the lookup chain.
+
+#include <string>
+#include <locale>
+#include <codecvt>
+
+namespace jni
+   {
+    inline std::u16string convertUTF8ToUTF16(const std::string& string)
+       {
+        return std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(string);
+       }
+
+    inline std::string convertUTF16ToUTF8(const std::u16string& string)
+       {
+        return std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().to_bytes(string);
+       }
+   }


### PR DESCRIPTION
This will make it easier to supply your own UTF-8/16 string conversion code rather than relying on the STL.