### PR TITLE
Thow IllegalStateException if native peer is dead.

### DIFF
--- a/include/jni/native_method.hpp
+++ b/include/jni/native_method.hpp
@@ -249,18 +249,13 @@ namespace jni
         return NativePeerFunctionPointerMethod<FunctionType, method>(name);
        }
 
-    enum class NativePeerNullCheck : bool {
-        Enabled = true,
-        Disabled = false
-    };
-
     /// High-level peer, member function pointer
 
-    template < class M, M, NativePeerNullCheck peerCheck = NativePeerNullCheck::Disabled>
+    template < class M, M>
     class NativePeerMemberFunctionMethod;
 
-    template < class R, class P, class... Args, R (P::*method)(JNIEnv&, Args...), NativePeerNullCheck peerCheck>
-    class NativePeerMemberFunctionMethod< R (P::*)(JNIEnv&, Args...), method, peerCheck>
+    template < class R, class P, class... Args, R (P::*method)(JNIEnv&, Args...)>
+    class NativePeerMemberFunctionMethod< R (P::*)(JNIEnv&, Args...), method>
        {
         private:
             const char* name;
@@ -275,23 +270,22 @@ namespace jni
                {
                 auto wrapper = [field] (JNIEnv& env, Object<TagType>& obj, Args... args)
                    {
-                    if (peerCheck == NativePeerNullCheck::Enabled and obj.Get(env, field) == 0) {
-                        ThrowNew(env,
-                                 jni::FindClass(env, "java/lang/IllegalStateException"),
-                                 "invalid native peer");
-                    }
-                    return (reinterpret_cast<P*>(obj.Get(env, field))->*method)(env, args...);
-                   };
+                    auto ptr = reinterpret_cast<P*>(obj.Get(env, field));
+                    if (ptr) return (ptr->*method)(env, args...);
+                    ThrowNew(env, jni::FindClass(env, "java/lang/IllegalStateException"),
+                             "invalid native peer");
+
+               };
 
                 return MakeNativeMethod(name, wrapper);
                }
        };
 
-    template < class M, M method, NativePeerNullCheck peerCheck = NativePeerNullCheck::Disabled>
+    template < class M, M method>
     auto MakeNativePeerMethod(const char* name,
                               std::enable_if_t< std::is_member_function_pointer<M>::value >* = nullptr)
        {
-        return NativePeerMemberFunctionMethod<M, method, peerCheck>(name);
+        return NativePeerMemberFunctionMethod<M, method>(name);
        }
 
 

--- a/include/jni/native_method.hpp
+++ b/include/jni/native_method.hpp
@@ -234,7 +234,10 @@ namespace jni
                {
                 auto wrapper = [field] (JNIEnv& env, Object<TagType>& obj, Args... args)
                    {
-                    return method(env, *reinterpret_cast<P*>(obj.Get(env, field)), args...);
+                    auto ptr = reinterpret_cast<P*>(obj.Get(env, field));
+                    if (ptr) return method(env, *ptr, args...);
+                    ThrowNew(env, jni::FindClass(env, "java/lang/IllegalStateException"),
+                             "invalid native peer");
                    };
 
                 return MakeNativeMethod(name, wrapper);
@@ -274,9 +277,7 @@ namespace jni
                     if (ptr) return (ptr->*method)(env, args...);
                     ThrowNew(env, jni::FindClass(env, "java/lang/IllegalStateException"),
                              "invalid native peer");
-
-               };
-
+                   };
                 return MakeNativeMethod(name, wrapper);
                }
        };


### PR DESCRIPTION
This fix is related to issue mapbox/mapbox-gl-native#15602.

 Between core sources (mbgl::style::Source) and android sources (mbgl::android::Source) there is bidirectional connection:

![source_connection](https://user-images.githubusercontent.com/208208/65680815-66f00900-e060-11e9-8b56-2c62a69c1356.png)

 When core source is added to the map, core layer takes ownership of the core source and during style update core source will be destroyed (together with android source, see picture above). If on the Java side the source object is still exists and used (by mistake),  then operations on will cause native crash (segfault by null pointer dereference). To avoid this situation, we should check native pointer and throw an exception to notify Java layer about this issue.

P.S. Keeping android peer by weak reference is not a solution, because it leads to memory and resource leaks (in particular, with GeoJsonSource those resources are threads).