### PR TITLE
promote UntaggedType constructor to public

### DIFF
--- a/include/jni/object.hpp
+++ b/include/jni/object.hpp
@@ -48,12 +48,12 @@ namespace jni
             using SuperType = typename TagTraits<TheTag>::SuperType;
             using UntaggedType = typename TagTraits<TheTag>::UntaggedType;
 
-        protected:
-            explicit Object(std::nullptr_t = nullptr)
-               {}
-
             explicit Object(UntaggedType* p)
                : SuperType(p)
+               {}
+
+        protected:
+            explicit Object(std::nullptr_t = nullptr)
                {}
 
             Object(const Object&) = delete;


### PR DESCRIPTION
This PR promotes the UntaggedType constructor from protected to public. 
Making these changes based on request from a customer. 