### PR TITLE
Let JVM print an exception and a backtrace of the stack.

### DIFF
--- a/include/jni/errors.hpp
+++ b/include/jni/errors.hpp
@@ -66,7 +66,10 @@ namespace jni
 
     inline void CheckJavaException(JNIEnv& env)
        {
-        if (env.ExceptionCheck()) throw PendingJavaException();
+        if (env.ExceptionCheck()) {
+            env.ExceptionDescribe();
+            throw PendingJavaException();
+        }
        }
 
     inline void CheckJavaExceptionThenErrorCode(JNIEnv& env, jint err)

--- a/test/android/jni.h
+++ b/test/android/jni.h
@@ -532,7 +532,7 @@ struct _JNIEnv {
     { return functions->ExceptionOccurred(this); }
 
     void ExceptionDescribe()
-    { functions->ExceptionDescribe(this); }
+    { if (functions->ExceptionDescribe) functions->ExceptionDescribe(this); }
 
     void ExceptionClear()
     { functions->ExceptionClear(this); }

--- a/test/openjdk/jni.h
+++ b/test/openjdk/jni.h
@@ -825,7 +825,7 @@ struct JNIEnv_ {
         return functions->ExceptionOccurred(this);
     }
     void ExceptionDescribe() {
-        functions->ExceptionDescribe(this);
+        if (functions->ExceptionDescribe) functions->ExceptionDescribe(this);
     }
     void ExceptionClear() {
         functions->ExceptionClear(this);


### PR DESCRIPTION
If an exception is thrown on Java side it's very hard to understand what and why it happens. For clarity let JVM print exception info to a log.