### PR TITLE
Fixes for GCC 9 and clang 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ BUILD := build/$(VARIANT)
 COMPILER := $(shell CXX="${CXX}" misc/compiler.sh)
 COMPILER_MAJOR_VERSION := $(shell CXX="${CXX}" misc/compiler-major-version.sh)
 
+$(info Compiler: "${COMPILER}" major version: "${COMPILER_MAJOR_VERSION}")
+
 ifeq ($(COMPILER), clang)
 	CXXFLAGS_WARNINGS := -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-exit-time-destructors
 	ifeq ($(shell test $(COMPILER_MAJOR_VERSION) -gt 4; echo $$?),0)

--- a/include/jni/unique.hpp
+++ b/include/jni/unique.hpp
@@ -47,12 +47,12 @@ namespace jni
             using Base = T;
             using UntaggedType = typename T::UntaggedType;
 
-            explicit Unique(std::nullptr_t ptr = nullptr)
-               : T(ptr),
+            explicit Unique(std::nullptr_t ptr_ = nullptr)
+               : T(ptr_),
                  deleter() {}
 
-            explicit Unique(JNIEnv& env, UntaggedType* ptr)
-               : T(ptr),
+            explicit Unique(JNIEnv& env, UntaggedType* ptr_)
+               : T(ptr_),
                  deleter(env) {}
 
             Unique(Unique&& other)
@@ -76,10 +76,10 @@ namespace jni
                 return *this;
                }
 
-            void reset(UntaggedType* ptr = nullptr)
+            void reset(UntaggedType* ptr_ = nullptr)
                {
                 UntaggedType* current = this->get();
-                T::reset(ptr);
+                T::reset(ptr_);
                 if (current)
                    {
                     get_deleter()(current);

--- a/include/jni/wrapping.hpp
+++ b/include/jni/wrapping.hpp
@@ -72,7 +72,7 @@ namespace jni
 
         ::jsize Unwrap(jsize s) const
            {
-            if (s > std::numeric_limits<::jsize>::max())
+            if (s > jsize(std::numeric_limits<::jsize>::max()))
                 throw std::range_error("jsize > max");
             return static_cast<::jsize>(s);
            }

--- a/misc/compiler-major-version.sh
+++ b/misc/compiler-major-version.sh
@@ -6,8 +6,8 @@ compiler=$(${CXX} -v 2>&1)
 
 case $compiler in
     *clang*|*gcc*)
-        version=`${CXX} --version | grep -o '\([0-9]\)\+.\([0-9]\)\+.\([0-9]\)\+'`
-        echo ${version::1}
+        version=`${CXX} --version | grep -o '\([0-9]\)\+.\([0-9]\)\+.\([0-9]\)\+' | sed -e 's/^\([0-9]*\).*/\1/' | head -n1`
+        echo "${version}"
         ;;
     *)
         echo

--- a/test/high_level.cpp
+++ b/test/high_level.cpp
@@ -669,15 +669,15 @@ int main()
 
         auto voidTrue = jni::MakeNativeMethod("voidTrue", [] (JNIEnv&, ObjectOrClass&, jni::jboolean b) { assert( b); });
         assert(voidTrue.signature == std::string("(Z)V"));
-        reinterpret_cast<jboolean (*)(JNIEnv*, jobject, jboolean)>(voidTrue.fnPtr)(&env, nullptr, JNI_TRUE);
+        reinterpret_cast<void (*)(JNIEnv*, jobject, jboolean)>(voidTrue.fnPtr)(&env, nullptr, JNI_TRUE);
 
         auto voidFalse = jni::MakeNativeMethod("voidFalse", [] (JNIEnv&, ObjectOrClass&, jni::jboolean b) { assert(!b); });
         assert(voidFalse.signature == std::string("(Z)V"));
-        reinterpret_cast<jboolean (*)(JNIEnv*, jobject, jboolean)>(voidFalse.fnPtr)(&env, nullptr, JNI_FALSE);
+        reinterpret_cast<void (*)(JNIEnv*, jobject, jboolean)>(voidFalse.fnPtr)(&env, nullptr, JNI_FALSE);
 
         auto voidObject = jni::MakeNativeMethod("voidObject", [] (JNIEnv&, ObjectOrClass&, jni::Object<Test>&) {});
         assert(voidObject.signature == std::string("(Lmapbox/com/Test;)V"));
-        reinterpret_cast<jboolean (*)(JNIEnv*, jobject, jobject)>(voidObject.fnPtr)(&env, nullptr, nullptr);
+        reinterpret_cast<void (*)(JNIEnv*, jobject, jobject)>(voidObject.fnPtr)(&env, nullptr, nullptr);
 
         auto objectVoid = jni::MakeNativeMethod("objectVoid", [] (JNIEnv&, ObjectOrClass&) -> jni::Local<jni::Object<Test>> { return jni::Local<jni::Object<Test>>(); });
         assert(objectVoid.signature == std::string("()Lmapbox/com/Test;"));


### PR DESCRIPTION
Currently, jni.hpp does not build in Ubuntu 20.04 with GCC 9 and clang 10. These commits fix the issues.