### PR TITLE
Crash native libs when unknown native exception is thrown

### DIFF
--- a/include/jni/errors.hpp
+++ b/include/jni/errors.hpp
@@ -117,9 +117,5 @@ namespace jni
            {
             env.ThrowNew(JavaErrorClass(env), e.what());
            }
-        catch (...)
-           {
-            env.ThrowNew(JavaErrorClass(env), "unknown native exception");
-           }
        }
    }


### PR DESCRIPTION
Crashing native library provides more debug information in case of unknown exception