### PR TITLE
Fix jni::AsLvalue not working on some versions of Clang.

### DIFF
--- a/include/jni/traits.hpp
+++ b/include/jni/traits.hpp
@@ -30,5 +30,5 @@ namespace jni
     template < class B1, class... Bn > struct Conjunction<B1, Bn...>
         : std::conditional_t<bool(B1::value), Conjunction<Bn...>, B1> {};
 
-    template < class T > T& AsLvalue(T&& x) { return x; }
+    template < class T > T& AsLvalue(T&& x) { return static_cast<T&>(x); }
    }


### PR DESCRIPTION
This implicit conversion is invalid on some versions of LLVM (I tested on llvm 14). However using a static_cast is valid.